### PR TITLE
Max vertical xterm

### DIFF
--- a/viewer/js-ui/editor.js
+++ b/viewer/js-ui/editor.js
@@ -113,3 +113,9 @@ document.getElementById('viewportSlider').addEventListener('input', function() {
     document.getElementById('editor-container').style.width = this.value + 'vw';
     document.getElementById('viewer').style.width = (100-this.value) + 'vw';
 }, false);
+
+document.getElementById('viewportSlider').addEventListener('wheel', function(e) {
+    this.value = this.value - e.deltaY / 100;
+    document.getElementById('editor-container').style.width = this.value + 'vw';
+    document.getElementById('viewer').style.width = (100-this.value) + 'vw';
+}, false);

--- a/viewer/js-ui/viewer.js
+++ b/viewer/js-ui/viewer.js
@@ -156,4 +156,12 @@ document.querySelector('#select-component').onchange = function(e) {
 
 document.querySelector('#select-component').onchange();
 
+    document.getElementById('xtermSlider').addEventListener('input', function() {
+	document.getElementById('output').style.height = this.value + 'px';
+    }, false);
+    document.getElementById('xtermSlider').addEventListener('wheel', function(e) {
+	this.value = this.value - e.deltaY / 4;
+	document.getElementById('output').style.height = this.value + 'px';
+    }, false);
+    
 })();

--- a/viewer/viewer.html
+++ b/viewer/viewer.html
@@ -29,7 +29,12 @@
   </section>
 
   <section id="serial">
-      <h2>Serial output</h2>
+      <div>
+	<h2>
+	  Serial output
+	  <input type="range" min="100" max="2000" value="400" class="slider" id="xtermSlider">
+	</h2>
+      </div>
       <div id="output"></div>
   </section>
 


### PR DESCRIPTION
Setting maximum vertical height automatically proved illogical since the viewport could be small enough to not let the terminal inside.
Instead another slider has been introduced so user can control terminal height.
Wheel events (scroll) have been implemented for both viewport slider and terminal height slider.