### PR TITLE
Pinned emsdk version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -qq && \
 RUN python3 -m pip install mbed-cli mercurial
 
 RUN git clone https://github.com/emscripten-core/emsdk
+RUN cd emsdk && git reset --hard 0b2084f # use emsdk 3.1.29
 
 RUN ln -s /emsdk /usr/lib/emsdk
 RUN npm update -g


### PR DESCRIPTION
So I tried to build the Docker container in here and it didn't work. Took me a good few tries to figure out that it was complaining about a version of `emsdk` that is too new for the `fastcomp` version of `emscripten`.

So I just pinned it to the commit of the version it suggested in the error message and now it builds!
